### PR TITLE
fix(tidal): fall back to find_album when the top hit is absent from search results

### DIFF
--- a/tests/tidal/test_client.py
+++ b/tests/tidal/test_client.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import Any
+
+import pytest
+from aiohttp import ClientSession
+
+from tidalidarr.tidal.client import TidalClient
+from tidalidarr.tidal.models import TidalAlbum, TidalConfig, TidalSearchResult
+
+
+def _album_payload() -> dict[str, Any]:
+    with Path("tests/tidal/data/album.json").open(mode="r", encoding="utf-8") as p:
+        return json.load(p)
+
+
+def _search_result(top_hit_id: int, albums: list[dict[str, Any]]) -> TidalSearchResult:
+    return TidalSearchResult(
+        artists={"items": []},
+        albums={"items": albums},
+        tracks={"items": []},
+        topHit={"type": "ALBUMS", "value": {"id": top_hit_id, "title": "top hit"}},
+    )
+
+
+def _search(
+    search_result: TidalSearchResult,
+    find_album: Callable[[int], Coroutine[Any, Any, TidalAlbum]],
+) -> Path | None:
+    async def fake_search(query: str) -> TidalSearchResult:  # noqa: ARG001
+        return search_result
+
+    async def run() -> Path | None:
+        async with ClientSession() as session:
+            config = TidalConfig(client_id="id", client_secret="secret")  # noqa: S106
+            client = TidalClient(config, session)
+            client._search = fake_search  # type: ignore[method-assign] # noqa: SLF001
+            client.find_album = find_album  # type: ignore[method-assign, assignment]
+            return await client.search("query")
+
+    return asyncio.run(run())
+
+
+def test_search_falls_back_to_find_album_when_top_hit_missing_from_albums() -> None:
+    album = TidalAlbum(**_album_payload())
+    calls: list[int] = []
+
+    async def find_album(album_id: int) -> TidalAlbum:
+        calls.append(album_id)
+        return album
+
+    folder = _search(_search_result(album.id, albums=[]), find_album)
+
+    assert folder == album.folder
+    assert calls == [album.id]
+
+
+def test_search_uses_album_from_search_results_when_present() -> None:
+    payload = _album_payload()
+    album = TidalAlbum(**payload)
+
+    async def find_album(album_id: int) -> TidalAlbum:
+        pytest.fail(f"find_album should not be called, got {album_id}")
+
+    folder = _search(_search_result(album.id, albums=[payload]), find_album)
+
+    assert folder == album.folder

--- a/tidalidarr/tidal/client.py
+++ b/tidalidarr/tidal/client.py
@@ -87,7 +87,7 @@ class TidalClient(TidalBaseClient):
         if query in self._not_found:
             del self._not_found[query]
 
-        album = next(a for a in search_result.albums if a.id == album_id)
+        album = next((a for a in search_result.albums if a.id == album_id), None) or await self.find_album(album_id)
         await self.enqueue_album(album)
         return album.folder
 


### PR DESCRIPTION
## Problem

Production traceback:

```
File "/usr/src/app/tidalidarr/tidal/client.py", line 90, in search
    album = next(a for a in search_result.albums if a.id == album_id)
StopIteration

The above exception was the direct cause of the following exception:
RuntimeError: coroutine raised StopIteration
```

Tidal computes `topHit` from its own relevance ranking, independently of the paginated `albums.items` list. When the top hit album id is not in that page, the bare `next()` raises `StopIteration`; inside a coroutine PEP 479 converts it to `RuntimeError`, the periodic check logs "There was an error during periodic check", and the query is silently dropped.

## Fix

Default the `next()` and fall back to the existing `find_album(album_id)`, which fetches the album by id — so the album is recovered instead of the query being lost.

## Tests

New `tests/tidal/test_client.py`:
- top hit missing from `albums` → falls back to `find_album`, returns the right folder
- top hit present in `albums` → uses the search result, never calls `find_album`

The first test reproduces the exact production `RuntimeError: coroutine raised StopIteration` against the old code and passes with the fix. Full suite: 33 passed; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)