### PR TITLE
fix(tidal): accept empty strings for artist picture and album cover

### DIFF
--- a/tests/tidal/test_models.py
+++ b/tests/tidal/test_models.py
@@ -66,3 +66,23 @@ def test_check_flac_magic() -> None:
     check_flac_magic(b"fLaC\x00\x00\x00\x22", track_id=1)
     with pytest.raises(TidalInvalidStreamError):
         check_flac_magic(b"\x00\x00\x00\x1cftypisom", track_id=1)
+
+
+def test_parse_search_result_with_empty_image_fields() -> None:
+    with Path("tests/tidal/data/search.json").open(mode="r", encoding="utf-8") as p:
+        content = json.load(p)
+    content["artists"]["items"][0]["picture"] = ""
+    content["albums"]["items"][0]["cover"] = ""
+
+    parsed = TidalSearchResult(**content)
+
+    assert parsed.artists[0].picture is None
+    assert parsed.albums[0].cover is None
+
+
+def test_album_without_cover_has_no_cover_urls() -> None:
+    with Path("tests/tidal/data/album.json").open(mode="r", encoding="utf-8") as p:
+        content = json.load(p)
+    content["cover"] = ""
+
+    assert TidalAlbum(**content).cover_urls == []

--- a/tidalidarr/tidal/models.py
+++ b/tidalidarr/tidal/models.py
@@ -4,13 +4,13 @@ from datetime import date
 from enum import Enum, StrEnum, auto
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 import mutagen
 import mutagen.flac
 import mutagen.id3
-from pydantic import BaseModel, ConfigDict, EmailStr, HttpUrl, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, EmailStr, HttpUrl, model_validator
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -127,10 +127,18 @@ class TidalToken(TidalModel):
     user: TidalUser
 
 
+def _empty_str_to_none(value: Any) -> Any:
+    """Tidal sends "" instead of null for missing images."""
+    return None if value == "" else value
+
+
+OptionalUUID = Annotated[UUID | None, BeforeValidator(_empty_str_to_none)]
+
+
 class TidalArtistStub(TidalModel):
     id: int
     name: str
-    picture: UUID | None = None
+    picture: OptionalUUID = None
 
 
 class TidalArtist(TidalArtistStub):
@@ -140,7 +148,7 @@ class TidalArtist(TidalArtistStub):
 class TidalAlbumStub(TidalModel):
     id: int
     title: str
-    cover: UUID
+    cover: OptionalUUID = None
 
 
 class TidalAlbum(TidalAlbumStub):
@@ -164,6 +172,8 @@ class TidalAlbum(TidalAlbumStub):
 
     @cached_property
     def cover_urls(self) -> list[HttpUrl]:
+        if not self.cover:
+            return []
         cover_path = str(self.cover).replace("-", "/")
         return [
             HttpUrl(f"https://resources.tidal.com/images/{cover_path}/{size}x{size}.jpg") for size in [640, 320, 160]


### PR DESCRIPTION
## Problem

Observed on 0.1.37 in production:

```
File "/usr/src/app/tidalidarr/tidal/client.py", line 121, in _search
    result = TidalSearchResult(**content)
pydantic_core._pydantic_core.ValidationError: 1 validation error for TidalSearchResult
artists.7.picture
  Input should be a valid UUID, invalid length: expected length 32 for simple format, found 0 [type=uuid_parsing, input_value='', input_type=str]
```

Tidal sends `""` instead of `null` for a missing image. Since the whole search response is validated as a single model, **one** picture-less artist anywhere in the results fails the entire query.

## Fix

- New `OptionalUUID` annotated type coercing `""` → `None`, applied to `TidalArtistStub.picture`.
- Same treatment for `TidalAlbumStub.cover`, which was a required `UUID` and carried the identical hazard — an album with no cover would have blown up a whole search the same way. `cover_urls` now returns `[]` in that case, which `_get_album_cover` already handles ("Could not find a cover for: …").

## Tests

- `test_parse_search_result_with_empty_image_fields` — empty `picture` and `cover` in a real search payload parse to `None`
- `test_album_without_cover_has_no_cover_urls`

Both reproduce the exact production `uuid_parsing` ValidationError against the old models and pass with the fix. Full suite: 35 passed; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)